### PR TITLE
Allows retrieving the tasks output from operator client terminal

### DIFF
--- a/nimbusc2_agent_lambda/agent_tasks.py
+++ b/nimbusc2_agent_lambda/agent_tasks.py
@@ -58,3 +58,29 @@ def get_task(session_id):
 
     # return the task for the intended session
     return pending_task
+
+def post_task(event_body):
+    """
+    store the task output in the S3 task folder
+    so c2 will be able to retrieve it based on the task_id
+    """
+    task_id = event_body["task"]["taskID"]
+    logging.info(f"storing the output of task: {task_id}")
+
+    # get the files to be used
+    tmp_task_file = f"/tmp/{task_id}"
+    s3_task_file = f"outputs/{task_id}"
+
+    # write event_body in json format to /tmp/
+    event_body_str = json.dumps(event_body)
+    with open(tmp_task_file, "w") as fp:
+        fp.write(event_body_str)
+
+    # get S3 bucket name
+    bucket_name = s3wrapper.get_s3_bucket_name()
+
+    # upload task file to S3
+    logging.info(f"uploading task output event body to S3...")
+    s3wrapper.put_s3_file(bucket_name, tmp_task_file, s3_task_file)
+
+    return

--- a/nimbusc2_agent_lambda/nimbusc2_agent_lambda.py
+++ b/nimbusc2_agent_lambda/nimbusc2_agent_lambda.py
@@ -92,10 +92,11 @@ def handle_get_task(event_body):
 
 def handle_post_task_output(event_body):
 
-    logging.info(f"received task output from agent:")
-
     # pretty print event_body
     print(json.dumps(event_body, indent=4))
+    logging.info(f"received task output from agent:")
+    agent_tasks.post_task(event_body)
+
     logging.info("task output:")
     print(event_body["task_output"])
     return {

--- a/pkg/lambdaC2/lambdac2.go
+++ b/pkg/lambdaC2/lambdac2.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var outputsKey string = "outputs/"
 var tasksKey string = "tasks/"
 var tmp string = "/tmp/"
 
@@ -111,7 +112,7 @@ func HandleGetLambdaTask(taskObj *tasker.TaskObject) (any, error) {
 
 	log.Info("getting task: ", taskObj.TaskID)
 
-	key := tasksKey + taskObj.TaskID
+	key := outputsKey + taskObj.TaskID
 	log.Debug("set S3 key: ", key)
 
 	outFile := tmp + taskObj.TaskID


### PR DESCRIPTION
This PR allows retrieving the tasks output from the operator client terminal.

In addition to printing the task output to be seen in CloudWatch, the agent lambda uploads the task output to S3. Then, the output can be retrieved by the operator client using the `--get-task` option.
